### PR TITLE
feat(modules/crush): expose NixOS and Home Manager module with options

### DIFF
--- a/modules/crush/default.nix
+++ b/modules/crush/default.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+let
+  crushOptions = import ./options.nix { inherit lib; };
+in
+{
+  options.programs.crush = {
+    enable = lib.mkEnableOption "Enable crush";
+    settings = crushOptions;
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf (config ? environment) (
+      lib.mkIf config.programs.crush.enable {
+        environment.systemPackages = [ (pkgs.callPackage ../../pkgs/crush { }) ];
+        environment.etc."crush/crush.json" = lib.mkIf (config.programs.crush.settings != { }) {
+          text = builtins.toJSON config.programs.crush.settings;
+          mode = "0644";
+        };
+      }
+    ))
+
+    (lib.mkIf (config ? home) (
+      lib.mkIf config.programs.crush.enable {
+        home.packages = [ (pkgs.callPackage ../../pkgs/crush { }) ];
+        home.file.".config/crush/crush.json" = lib.mkIf (config.programs.crush.settings != { }) {
+          text = builtins.toJSON config.programs.crush.settings;
+        };
+      }
+    ))
+  ];
+}

--- a/modules/crush/options.nix
+++ b/modules/crush/options.nix
@@ -1,0 +1,171 @@
+{ lib }:
+
+lib.mkOption {
+  type = lib.types.submodule {
+    options = {
+      providers = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              id = lib.mkOption {
+                type = lib.types.str;
+                description = "Unique identifier for the provider";
+              };
+              name = lib.mkOption {
+                type = lib.types.str;
+                description = "Human-readable name for the provider";
+              };
+              base_url = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                description = "Base URL for the provider's API";
+              };
+              type = lib.mkOption {
+                type = lib.types.enum [ "openai" "anthropic" "gemini" "azure" "vertexai" ];
+                default = "openai";
+                description = "Provider type that determines the API format";
+              };
+              api_key = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                description = "API key for authentication with the provider";
+              };
+              disable = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Whether this provider is disabled";
+              };
+              system_prompt_prefix = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                description = "Custom prefix to add to system prompts for this provider";
+              };
+              extra_headers = lib.mkOption {
+                type = lib.types.attrsOf lib.types.str;
+                default = { };
+                description = "Additional HTTP headers to send with requests";
+              };
+              extra_body = lib.mkOption {
+                type = lib.types.attrsOf lib.types.anything;
+                default = { };
+                description = "Additional fields to include in request bodies";
+              };
+              models = lib.mkOption {
+                type = lib.types.listOf (
+                  lib.types.submodule {
+                    options = {
+                      id = lib.mkOption { type = lib.types.str; description = "Model ID"; };
+                      name = lib.mkOption { type = lib.types.str; description = "Model display name"; };
+                      cost_per_1m_in = lib.mkOption { type = lib.types.float; default = 0; };
+                      cost_per_1m_out = lib.mkOption { type = lib.types.float; default = 0; };
+                      cost_per_1m_in_cached = lib.mkOption { type = lib.types.float; default = 0; };
+                      cost_per_1m_out_cached = lib.mkOption { type = lib.types.float; default = 0; };
+                      context_window = lib.mkOption { type = lib.types.int; default = 128000; };
+                      default_max_tokens = lib.mkOption { type = lib.types.int; default = 8192; };
+                      can_reason = lib.mkOption { type = lib.types.bool; default = false; };
+                      has_reasoning_efforts = lib.mkOption { type = lib.types.bool; default = false; };
+                      default_reasoning_effort = lib.mkOption { type = lib.types.str; default = ""; };
+                      supports_attachments = lib.mkOption { type = lib.types.bool; default = false; };
+                    };
+                  }
+                );
+                default = [ ];
+                description = "List of models available from this provider";
+              };
+            };
+          }
+        );
+        default = { };
+        description = "AI provider configurations";
+      };
+
+      lsp = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              command = lib.mkOption { type = lib.types.str; description = "Command to execute for the LSP server"; };
+              args = lib.mkOption { type = lib.types.listOf lib.types.str; default = [ ]; description = "Arguments to pass to the LSP server command"; };
+              options = lib.mkOption { type = lib.types.attrsOf lib.types.anything; default = { }; description = "LSP server-specific configuration options"; };
+              enabled = lib.mkOption { type = lib.types.bool; default = false; description = "Whether this LSP server is disabled"; };
+            };
+          }
+        );
+        default = { };
+        description = "Language Server Protocol configurations";
+      };
+
+      mcp = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              command = lib.mkOption { type = lib.types.str; default = ""; description = "Command to execute for stdio MCP servers"; };
+              env = lib.mkOption { type = lib.types.attrsOf lib.types.str; default = { }; description = "Environment variables to set for the MCP server"; };
+              args = lib.mkOption { type = lib.types.listOf lib.types.str; default = [ ]; description = "Arguments to pass to the MCP server command"; };
+              type = lib.mkOption { type = lib.types.enum [ "stdio" "sse" "http" ]; default = "stdio"; description = "Type of MCP connection"; };
+              url = lib.mkOption { type = lib.types.str; default = ""; description = "URL for HTTP or SSE MCP servers"; };
+              disabled = lib.mkOption { type = lib.types.bool; default = false; description = "Whether this MCP server is disabled"; };
+              headers = lib.mkOption { type = lib.types.attrsOf lib.types.str; default = { }; description = "HTTP headers for HTTP/SSE MCP servers"; };
+            };
+          }
+        );
+        default = { };
+        description = "Model Context Protocol server configurations";
+      };
+
+      options = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            context_paths = lib.mkOption { type = lib.types.listOf lib.types.str; default = [ ]; description = "Paths to files containing context information for the AI"; };
+            tui = lib.mkOption {
+              type = lib.types.submodule {
+                options = {
+                  compact_mode = lib.mkOption { type = lib.types.bool; default = false; description = "Enable compact mode for the TUI interface"; };
+                };
+              };
+              default = { };
+              description = "Terminal user interface options";
+            };
+            debug = lib.mkOption { type = lib.types.bool; default = false; description = "Enable debug logging"; };
+            debug_lsp = lib.mkOption { type = lib.types.bool; default = false; description = "Enable debug logging for LSP servers"; };
+            disable_auto_summarize = lib.mkOption { type = lib.types.bool; default = false; description = "Disable automatic conversation summarization"; };
+            data_directory = lib.mkOption { type = lib.types.str; default = ".crush"; description = "Directory for storing application data (relative to working directory)"; };
+          };
+        };
+        default = { };
+        description = "General application options";
+      };
+
+      permissions = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            allowed_tools = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "List of tools that don't require permission prompts";
+            };
+          };
+        };
+        default = { };
+        description = "Permission settings for tool usage";
+      };
+
+      models = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              model = lib.mkOption { type = lib.types.str; description = "The model ID as used by the provider API"; };
+              provider = lib.mkOption { type = lib.types.str; description = "The model provider ID that matches a key in the providers config"; };
+              reasoning_effort = lib.mkOption { type = lib.types.enum [ "low" "medium" "high" ]; default = ""; description = "Reasoning effort level for OpenAI models that support it"; };
+              max_tokens = lib.mkOption { type = lib.types.int; default = 0; description = "Maximum number of tokens for model responses"; };
+              think = lib.mkOption { type = lib.types.bool; default = false; description = "Enable thinking mode for Anthropic models that support reasoning"; };
+            };
+          }
+        );
+        default = { };
+        description = "Model configurations";
+      };
+    };
+  };
+  default = { };
+  description = "Crush configuration options";
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,5 +1,3 @@
 {
-  # Add your NixOS modules here
-  #
-  # my-module = ./my-module;
+  crush = ./crush;
 }


### PR DESCRIPTION
## Summary
- Add NixOS/Home Manager module under modules/crush with shared options
- Expose as `nur.repos.charmbracelet.modules.crush`

## Usage (NixOS)
```nix
{
  inputs.nur.url = "github:nix-community/NUR";
  outputs = { nixpkgs, nur, ... }: {
    nixosConfigurations.host = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        nur.modules.nixos.default
        nur.repos.charmbracelet.modules.crush
        {
          programs.crush.enable = true;
          programs.crush.settings = {
            providers.openai = {
              name = "OpenAI";
              type = "openai";
              api_key = "env:OPENAI_API_KEY";
            };
            models.default = { model = "gpt-4o"; provider = "openai"; };
          };
        }
      ];
    };
  };
}
```

## Usage (Home Manager)
```nix
{
  inputs.nur.url = "github:nix-community/NUR";
  outputs = { nixpkgs, nur, ... }: {
    homeConfigurations.user = nixpkgs.lib.homeManagerConfiguration {
      pkgs = import nixpkgs { system = "x86_64-linux"; };
      modules = [
        nur.repos.charmbracelet.modules.crush
        {
          programs.crush.enable = true;
          programs.crush.settings = { options.tui.compact_mode = true; };
        }
      ];
    };
  };
}
```

## Behavior
- Installs crush in system/home packages when enabled
- Writes crush.json (NixOS: /etc/crush/crush.json, HM: ~/.config/crush/crush.json) from settings

💘 Generated with Crush