### PR TITLE
charm: deprecate charm cli

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,7 @@
   modules = import ./modules; # NixOS modules
   overlays = import ./overlays; # nixpkgs overlays
 
+  # charm: DEPRECATED - will be removed July 2026
   charm = pkgs.callPackage ./pkgs/charm { };
   confettysh = pkgs.callPackage ./pkgs/confettysh { };
   crush = pkgs.callPackage ./pkgs/crush { };

--- a/pkgs/charm/default.nix
+++ b/pkgs/charm/default.nix
@@ -41,9 +41,10 @@ in pkgs.stdenv.mkDerivation {
   system = system;
 
   meta = with lib; {
-    description = "The Charm Tool and Library 🌟";
+    description = "The Charm Tool and Library 🌟 (deprecated: will be removed July 2026)";
     homepage = "https://charm.sh/";
     license = licenses.mit;
+    broken = true;
 
     platforms = [
       "aarch64-darwin"


### PR DESCRIPTION
The charm cli has been archived for over a year now so it is time for removal; will remove completely july 2026