### PR TITLE
crush: add api_key_file and api_key_command provider options

### DIFF
--- a/modules/crush/options/settings.nix
+++ b/modules/crush/options/settings.nix
@@ -464,6 +464,29 @@ lib.mkOption {
                 description = "API key for authentication with the provider";
               };
 
+              api_key_command = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = ''
+                  Shell command whose stdout provides the API key. The command
+                  is executed at runtime; crush reads the first line of output
+                  as the key. Takes precedence over api_key but not
+                  api_key_file.
+                '';
+              };
+
+              api_key_file = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = null;
+                description = ''
+                  Path to a file containing the API key. The first line of the
+                  file is read as the key. Takes precedence over both api_key
+                  and api_key_command. Use this to reference secrets managed by
+                  agenix, sops-nix, or similar tools without storing the key in
+                  the Nix store.
+                '';
+              };
+
               base_url = lib.mkOption {
                 type = lib.types.nullOr lib.types.str;
                 default = null;

--- a/modules/crush/options/settings.nix
+++ b/modules/crush/options/settings.nix
@@ -476,7 +476,7 @@ lib.mkOption {
               };
 
               api_key_file = lib.mkOption {
-                type = lib.types.nullOr lib.types.path;
+                type = lib.types.nullOr lib.types.str;
                 default = null;
                 description = ''
                   Path to a file containing the API key. The first line of the


### PR DESCRIPTION
crush natively supports api_key_file (reads first line of a file) and api_key_command (runs a command, reads first line of stdout) as authentication methods in its JSON config.

This PR adds the corresponding NixOS/Home Manager module options so users can reference secrets managed by agenix, sops-nix, or similar tools.